### PR TITLE
Retry after mongo disconnection

### DIFF
--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -107,13 +107,13 @@ class Slurper implements Runnable {
                         logger.warn("Exception while looping in cursor, retry in 10 seconds", ex);
 //                      Thread.currentThread().interrupt();
 //                      break;
-                        startTimestamp=getCurrentOplogTimestamp();
+                        startTimestamp = getCurrentOplogTimestamp();
                         try {
                             Thread.sleep(10000);
                         } catch (Exception sleepex) {
-                            logger.warn("Thread interrupted");
-                            Thread.currentThread().interrupt();
-                            break;
+                            logger.error("Thread interrupted", sleepex);
+//                          Thread.currentThread().interrupt();
+//                          break;
                         }
                     } finally {
                         if (cursor != null) {

--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -92,24 +92,35 @@ class Slurper implements Runnable {
 
                 // Slurp from oplog
                 DBCursor cursor = null;
-                try {
-                    cursor = oplogCursor(startTimestamp);
-                    if (cursor == null) {
-                        cursor = processFullOplog();
-                    }
-                    while (cursor.hasNext()) {
-                        DBObject item = cursor.next();
-                        processOplogEntry(item, startTimestamp);
-                    }
-                    Thread.sleep(500);
-                } catch (Exception ex) {
-                    logger.warn("Exception while looping in cursor", ex);
-                    Thread.currentThread().interrupt();
-                    break;
-                } finally {
-                    if (cursor != null) {
-                        logger.trace("Closing oplog cursor");
-                        cursor.close();
+                while (true) { //Re-obtain cursor upon disconnection
+                    try {
+                        cursor = oplogCursor(startTimestamp);
+                        if (cursor == null) {
+                            cursor = processFullOplog();
+                        }
+                        while (cursor.hasNext()) {
+                            DBObject item = cursor.next();
+                            processOplogEntry(item, startTimestamp);
+                        }
+                        Thread.sleep(500);
+                    } catch (Exception ex) {
+                        logger.warn("Exception while looping in cursor, retry in 10 seconds", ex);
+//                      Thread.currentThread().interrupt();
+//                      break;
+                        startTimestamp=getCurrentOplogTimestamp();
+                        try {
+                            Thread.sleep(10000);
+                        } catch (Exception sleepex) {
+                            logger.warn("Thread interrupted");
+                            Thread.currentThread().interrupt();
+                            break;
+                        }
+                        continue;
+                    } finally {
+                        if (cursor != null) {
+                            logger.trace("Closing oplog cursor");
+                            cursor.close();
+                        }
                     }
                 }
             } catch (MongoInterruptedException mIEx) {

--- a/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
+++ b/src/main/java/org/elasticsearch/river/mongodb/Slurper.java
@@ -115,7 +115,6 @@ class Slurper implements Runnable {
                             Thread.currentThread().interrupt();
                             break;
                         }
-                        continue;
                     } finally {
                         if (cursor != null) {
                             logger.trace("Closing oplog cursor");


### PR DESCRIPTION
When a mongo instance whose oplog is being tailed by the river is restarted, the river will crash. This will make river wait a while and get a new cursor to tail the oplog rather than commit suicide.
